### PR TITLE
Finalize diffusion normalizer

### DIFF
--- a/scripts/prepare_finetune_data.py
+++ b/scripts/prepare_finetune_data.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import argparse
+
+from src.learning.ft_dataset import build_finetune_dataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create fine-tuning dataset from success memory")
+    parser.add_argument("data_dir", type=Path, help="Directory containing success_memory.jsonl")
+    parser.add_argument("output", type=Path, help="Output JSONL dataset path")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    success = build_finetune_dataset(args.data_dir, args.output, verbose=args.verbose)
+    if not success:
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_assistant.py
+++ b/scripts/run_assistant.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Minimal CLI wrapper for running the assistant on a spec."""
+import argparse
+from pathlib import Path
+import yaml
+
+from src.utils.config_loader import load_app_config
+from src.planner.phase_planner import PhasePlanner
+from src.planner.spec_model import Spec
+from src.digester.repository_digester import RepositoryDigester
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run diffuseLLM assistant on a spec YAML")
+    parser.add_argument("spec", type=Path, help="Path to YAML spec")
+    parser.add_argument("--project-root", type=Path, default=Path.cwd(), help="Project root")
+    parser.add_argument("--config", type=Path, default=None, help="Optional config YAML")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    app_config = load_app_config(args.config)
+    app_config["general"]["project_root"] = str(args.project_root.resolve())
+    if args.verbose:
+        app_config["general"]["verbose"] = True
+
+    with open(args.spec, "r", encoding="utf-8") as f:
+        spec_data = yaml.safe_load(f)
+    spec = Spec(**spec_data)
+
+    digester = RepositoryDigester(repo_path=args.project_root, app_config=app_config)
+    planner = PhasePlanner(project_root_path=args.project_root, app_config=app_config, digester=digester)
+
+    planner.plan_phases(spec)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_core_predictor.py
+++ b/scripts/train_core_predictor.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import argparse
+
+from src.learning.core_predictor import CorePredictor
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train the CorePredictor from success memory")
+    parser.add_argument("data_dir", type=Path, help="Directory containing success_memory.jsonl")
+    parser.add_argument("--model-path", type=Path, default=Path("./models/core_predictor.joblib"))
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    predictor = CorePredictor(model_path=args.model_path, verbose=args.verbose)
+    ok = predictor.train(training_data_path=args.data_dir, model_output_path=args.model_path)
+    if not ok:
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent_group/diffusion_core.py
+++ b/src/agent_group/diffusion_core.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 import re
-import textwrap # Added for intelligent indentation
+import textwrap  # Added for intelligent indentation
 
 # Attempt to import get_llm_code_infill and get_divot5_code_infill, handle if not available
 try:
@@ -9,14 +9,17 @@ try:
 except ImportError:
     get_llm_code_infill = None
     get_divot5_code_infill = None
-    DEFAULT_APP_CONFIG = { # Basic fallback for model paths if main import fails
+    DEFAULT_APP_CONFIG = {  # Basic fallback for model paths if main import fails
         "models": {
             "agent_llm_gguf": "./models/placeholder_llm_agent.gguf",
-            "divot5_infill_model_dir": "./models/placeholder_divot5_infill/"
+            "divot5_infill_model_dir": "./models/placeholder_divot5_infill/",
         },
-        "llm_params": {}, "divot5_fim_params": {} # Empty dicts for params
+        "llm_params": {},
+        "divot5_fim_params": {},  # Empty dicts for params
     }
-    print("DiffusionCore Warning: Failed to import LLM interfacer functions or DEFAULT_APP_CONFIG. LLM-based infilling will be disabled or use basic fallbacks.")
+    print(
+        "DiffusionCore Warning: Failed to import LLM interfacer functions or DEFAULT_APP_CONFIG. LLM-based infilling will be disabled or use basic fallbacks."
+    )
 
 
 class DiffusionCore:
@@ -28,13 +31,20 @@ class DiffusionCore:
             style_profile: Dictionary containing style profile information.
         """
         self.app_config = app_config
-        self.style_profile = style_profile # Store style_profile if needed by other methods
+        self.style_profile = (
+            style_profile  # Store style_profile if needed by other methods
+        )
         self.verbose = self.app_config.get("general", {}).get("verbose", False)
         if self.verbose:
             print(f"DiffusionCore initialized. Verbose: {self.verbose}")
             print(f"  Style profile keys: {list(self.style_profile.keys())}")
 
-    def expand_scaffold(self, scaffold_patch_script: Optional[str], edit_summary_str: Optional[str], context_data: Dict[str, Any]) -> Optional[str]:
+    def expand_scaffold(
+        self,
+        scaffold_patch_script: Optional[str],
+        edit_summary_str: Optional[str],
+        context_data: Dict[str, Any],
+    ) -> Optional[str]:
         """
         Expands placeholders in a scaffold LibCST patch script using LLM-based code infilling.
         Args:
@@ -44,42 +54,70 @@ class DiffusionCore:
         Returns:
             The completed LibCST script string with placeholders filled, or the original/partially filled on error.
         """
-        print(f"DiffusionCore.expand_scaffold called. Context keys: {list(context_data.keys())}. Edit summary: '{edit_summary_str}'")
+        print(
+            f"DiffusionCore.expand_scaffold called. Context keys: {list(context_data.keys())}. Edit summary: '{edit_summary_str}'"
+        )
 
         if not scaffold_patch_script:
-            if self.verbose: print("DiffusionCore Warning: Received None or empty scaffold_patch_script. Returning as is.")
+            if self.verbose:
+                print(
+                    "DiffusionCore Warning: Received None or empty scaffold_patch_script. Returning as is."
+                )
             return scaffold_patch_script
 
-        if self.verbose: print(f"  Initial scaffold script (first 200 chars): '{scaffold_patch_script[:200]}...'")
+        if self.verbose:
+            print(
+                f"  Initial scaffold script (first 200 chars): '{scaffold_patch_script[:200]}...'"
+            )
 
         agent_infill_config = self.app_config.get("agent_infill", {})
         infill_type = agent_infill_config.get("type", "gguf").lower()
         llm_params = self.app_config.get("llm_params", {})
         divot5_params = self.app_config.get("divot5_fim_params", {})
-        llm_interfacer_verbose = self.app_config.get("general", {}).get("verbose_llm_calls", self.verbose)
+        llm_interfacer_verbose = self.app_config.get("general", {}).get(
+            "verbose_llm_calls", self.verbose
+        )
 
         infill_model_path: Optional[str] = None
         can_infill = False
 
         if infill_type == "gguf":
-            infill_model_path = self.app_config.get("models", {}).get("infill_llm_gguf",
-                                                                    self.app_config.get("models", {}).get("agent_llm_gguf",
-                                                                                                          DEFAULT_APP_CONFIG["models"]["agent_llm_gguf"]))
+            infill_model_path = self.app_config.get("models", {}).get(
+                "infill_llm_gguf",
+                self.app_config.get("models", {}).get(
+                    "agent_llm_gguf", DEFAULT_APP_CONFIG["models"]["agent_llm_gguf"]
+                ),
+            )
             can_infill = get_llm_code_infill is not None and bool(infill_model_path)
             if not can_infill and self.verbose:
-                if get_llm_code_infill is None: print("DiffusionCore Info: get_llm_code_infill (for GGUF) not available.")
-                if not infill_model_path: print("DiffusionCore Info: GGUF infill model path not configured.")
+                if get_llm_code_infill is None:
+                    print(
+                        "DiffusionCore Info: get_llm_code_infill (for GGUF) not available."
+                    )
+                if not infill_model_path:
+                    print("DiffusionCore Info: GGUF infill model path not configured.")
         elif infill_type == "divot5":
-            infill_model_path = self.app_config.get("models", {}).get("divot5_infill_model_dir", DEFAULT_APP_CONFIG["models"]["divot5_infill_model_dir"])
+            infill_model_path = self.app_config.get("models", {}).get(
+                "divot5_infill_model_dir",
+                DEFAULT_APP_CONFIG["models"]["divot5_infill_model_dir"],
+            )
             can_infill = get_divot5_code_infill is not None and bool(infill_model_path)
             if not can_infill and self.verbose:
-                if get_divot5_code_infill is None: print("DiffusionCore Info: get_divot5_code_infill not available.")
-                if not infill_model_path: print("DiffusionCore Info: DivoT5 infill model path not configured.")
+                if get_divot5_code_infill is None:
+                    print("DiffusionCore Info: get_divot5_code_infill not available.")
+                if not infill_model_path:
+                    print(
+                        "DiffusionCore Info: DivoT5 infill model path not configured."
+                    )
         else:
-            print(f"DiffusionCore Warning: Unknown infill type '{infill_type}' configured. Skipping real infill.")
+            print(
+                f"DiffusionCore Warning: Unknown infill type '{infill_type}' configured. Skipping real infill."
+            )
 
         if not can_infill and self.verbose:
-            print("DiffusionCore Info: Real LLM infill will be skipped due to missing function or model path.")
+            print(
+                "DiffusionCore Info: Real LLM infill will be skipped due to missing function or model path."
+            )
 
         current_script_variant = scaffold_patch_script
 
@@ -93,11 +131,11 @@ class DiffusionCore:
             return current_script_variant
 
         for match in reversed(matches):
-            hole_marker = match.group(1) # e.g., "__HOLE_0__"
-            hole_number_str = match.group(2) # e.g., "0"
+            hole_marker = match.group(1)  # e.g., "__HOLE_0__"
+            hole_number_str = match.group(2)  # e.g., "0"
 
-            code_before_hole = current_script_variant[:match.start()]
-            code_after_hole = current_script_variant[match.end():]
+            code_before_hole = current_script_variant[: match.start()]
+            code_after_hole = current_script_variant[match.end() :]
 
             # Attempt to find relevant part of edit_summary for this specific hole
             # This is a heuristic; more advanced context mapping might be needed.
@@ -137,23 +175,40 @@ Provide only the code snippet to replace `{hole_marker}`:"""
 
             if can_infill and infill_model_path:
                 if infill_type == "gguf":
-                    gguf_n_gpu_layers = llm_params.get("n_gpu_layers_default", DEFAULT_APP_CONFIG["llm_params"]["n_gpu_layers_default"])
-                    gguf_n_ctx = llm_params.get("n_ctx_default", DEFAULT_APP_CONFIG["llm_params"]["n_ctx_default"])
-                    gguf_max_tokens = llm_params.get("agent_infill_gguf_max_tokens", DEFAULT_APP_CONFIG["llm_params"]["agent_infill_gguf_max_tokens"])
-                    gguf_temp = llm_params.get("agent_infill_gguf_temp", DEFAULT_APP_CONFIG["llm_params"]["temperature_default"])
+                    gguf_n_gpu_layers = llm_params.get(
+                        "n_gpu_layers_default",
+                        DEFAULT_APP_CONFIG["llm_params"]["n_gpu_layers_default"],
+                    )
+                    gguf_n_ctx = llm_params.get(
+                        "n_ctx_default",
+                        DEFAULT_APP_CONFIG["llm_params"]["n_ctx_default"],
+                    )
+                    gguf_max_tokens = llm_params.get(
+                        "agent_infill_gguf_max_tokens",
+                        DEFAULT_APP_CONFIG["llm_params"][
+                            "agent_infill_gguf_max_tokens"
+                        ],
+                    )
+                    gguf_temp = llm_params.get(
+                        "agent_infill_gguf_temp",
+                        DEFAULT_APP_CONFIG["llm_params"]["temperature_default"],
+                    )
                     # stop_sequences might need to be configured in llm_params too
-                    stop_sequences = llm_params.get("agent_infill_gguf_stop_sequences", ["\n```", "\n# End of infill"])
+                    stop_sequences = llm_params.get(
+                        "agent_infill_gguf_stop_sequences",
+                        ["\n```", "\n# End of infill"],
+                    )
 
                     if get_llm_code_infill:
                         infilled_code_snippet = get_llm_code_infill(
                             model_path=infill_model_path,
-                            prompt=prompt, # This prompt might need adjustment for GGUF FIM models
+                            prompt=prompt,  # This prompt might need adjustment for GGUF FIM models
                             verbose=llm_interfacer_verbose,
                             n_gpu_layers=gguf_n_gpu_layers,
                             n_ctx=gguf_n_ctx,
                             max_tokens_for_infill=gguf_max_tokens,
                             temperature=gguf_temp,
-                            stop=stop_sequences
+                            stop=stop_sequences,
                         )
                         llm_call_succeeded = infilled_code_snippet is not None
 
@@ -161,64 +216,98 @@ Provide only the code snippet to replace `{hole_marker}`:"""
                     # DivoT5 prompt might need to be structured with <PREFIX>, <SUFFIX>, <MIDDLE>
                     # For now, using the same generic prompt; this will likely need refinement.
                     # Example DivoT5 prompt structure: f"<PREFIX>{code_before_hole[-500:]}<SUFFIX>{code_after_hole[:500]}<MIDDLE>"
-                    divot5_prompt = f"<PREFIX>{code_before_hole[-500:]}<SUFFIX>{code_after_hole[:500]}<MIDDLE>" # Example specific prompt
+                    divot5_prompt = f"<PREFIX>{code_before_hole[-500:]}<SUFFIX>{code_after_hole[:500]}<MIDDLE>"  # Example specific prompt
 
-                    divot5_max_length = divot5_params.get("infill_max_length", DEFAULT_APP_CONFIG["divot5_fim_params"]["infill_max_length"])
-                    divot5_num_beams = divot5_params.get("infill_num_beams", DEFAULT_APP_CONFIG["divot5_fim_params"]["infill_num_beams"])
-                    divot5_temp = divot5_params.get("infill_temperature", DEFAULT_APP_CONFIG["divot5_fim_params"]["infill_temperature"])
+                    divot5_max_length = divot5_params.get(
+                        "infill_max_length",
+                        DEFAULT_APP_CONFIG["divot5_fim_params"]["infill_max_length"],
+                    )
+                    divot5_num_beams = divot5_params.get(
+                        "infill_num_beams",
+                        DEFAULT_APP_CONFIG["divot5_fim_params"]["infill_num_beams"],
+                    )
+                    divot5_temp = divot5_params.get(
+                        "infill_temperature",
+                        DEFAULT_APP_CONFIG["divot5_fim_params"]["infill_temperature"],
+                    )
 
                     if get_divot5_code_infill:
                         infilled_code_snippet = get_divot5_code_infill(
-                            model_dir_path=infill_model_path, # DivoT5 usually loaded from a directory
-                            prompt=divot5_prompt, # Use the DivoT5 specific prompt
+                            model_dir_path=infill_model_path,  # DivoT5 usually loaded from a directory
+                            prompt=divot5_prompt,  # Use the DivoT5 specific prompt
                             max_length=divot5_max_length,
                             num_beams=divot5_num_beams,
                             temperature=divot5_temp,
-                            verbose=llm_interfacer_verbose
+                            verbose=llm_interfacer_verbose,
                         )
                         llm_call_succeeded = infilled_code_snippet is not None
 
-            if llm_call_succeeded and isinstance(infilled_code_snippet, str) and infilled_code_snippet.strip():
+            if (
+                llm_call_succeeded
+                and isinstance(infilled_code_snippet, str)
+                and infilled_code_snippet.strip()
+            ):
                 # Start of new indentation logic
                 hole_start_col = match.start()
                 # Find the start of the line containing the hole
-                line_start_pos = current_script_variant.rfind('\n', 0, hole_start_col) + 1
+                line_start_pos = (
+                    current_script_variant.rfind("\n", 0, hole_start_col) + 1
+                )
                 hole_indent_level = hole_start_col - line_start_pos
                 hole_indent_str = " " * hole_indent_level
 
-                cleaned_snippet = infilled_code_snippet.strip() # Remove leading/trailing whitespace/newlines
+                cleaned_snippet = (
+                    infilled_code_snippet.strip()
+                )  # Remove leading/trailing whitespace/newlines
                 if not cleaned_snippet:
                     final_infilled_code = ""
                 else:
                     dedented_snippet = textwrap.dedent(cleaned_snippet)
                     if not dedented_snippet.strip():
-                         final_infilled_code = hole_indent_str
+                        final_infilled_code = hole_indent_str
                     else:
-                         indented_snippet_lines = [hole_indent_str + line for line in dedented_snippet.splitlines()]
-                         final_infilled_code = "\n".join(indented_snippet_lines)
+                        indented_snippet_lines = [
+                            hole_indent_str + line
+                            for line in dedented_snippet.splitlines()
+                        ]
+                        final_infilled_code = "\n".join(indented_snippet_lines)
 
-                current_script_variant = code_before_hole + final_infilled_code + code_after_hole
-                print(f"DiffusionCore: Successfully filled {hole_marker} with LLM output (length {len(final_infilled_code)}), applied indentation.")
+                current_script_variant = (
+                    code_before_hole + final_infilled_code + code_after_hole
+                )
+                print(
+                    f"DiffusionCore: Successfully filled {hole_marker} with LLM output (length {len(final_infilled_code)}), applied indentation."
+                )
                 # End of new indentation logic
             else:
                 failure_reason = "LLM returned no content"
-                if not llm_infill_available: failure_reason = "LLM infill function not available"
-                elif not infill_model_path: failure_reason = "Infill model path not configured"
-                elif not llm_call_succeeded : failure_reason = "LLM call failed or returned None"
+                if not llm_infill_available:
+                    failure_reason = "LLM infill function not available"
+                elif not infill_model_path:
+                    failure_reason = "Infill model path not configured"
+                elif not llm_call_succeeded:
+                    failure_reason = "LLM call failed or returned None"
 
                 replacement_comment = f"# FAILED_TO_FILL_HOLE_{hole_number_str} - Reason: {failure_reason}"
-                current_script_variant = code_before_hole + replacement_comment + code_after_hole
-                print(f"DiffusionCore: Failed to fill {hole_marker}. Replaced with comment: '{replacement_comment}'. Reason: {failure_reason}")
+                current_script_variant = (
+                    code_before_hole + replacement_comment + code_after_hole
+                )
+                print(
+                    f"DiffusionCore: Failed to fill {hole_marker}. Replaced with comment: '{replacement_comment}'. Reason: {failure_reason}"
+                )
 
         completed_patch_script = current_script_variant
-        print(f"DiffusionCore: Finished expanding scaffold. Final script (first 200 chars): '{completed_patch_script[:200]}...'")
+        print(
+            f"DiffusionCore: Finished expanding scaffold. Final script (first 200 chars): '{completed_patch_script[:200]}...'"
+        )
         return completed_patch_script
 
-    def re_denoise_spans(self,
-                         failed_patch_script: Optional[str],
-                         proposed_fix_script: Optional[str],
-                         context_data: Dict[str, Any]
-                         ) -> Optional[str]:
+    def re_denoise_spans(
+        self,
+        failed_patch_script: Optional[str],
+        proposed_fix_script: Optional[str],
+        context_data: Dict[str, Any],
+    ) -> Optional[str]:
         """
         Currently, this method passes through the proposed_fix_script from LLMCore,
         with a specific check for full script replacement markers.
@@ -232,62 +321,89 @@ Provide only the code snippet to replace `{hole_marker}`:"""
             The script to be used for the next repair attempt (currently, proposed_fix_script), or None.
         """
         if self.verbose:
-            failed_script_preview = f"(length: {len(failed_patch_script)}) {failed_patch_script[:100]}..." if failed_patch_script else "None"
-            proposed_script_preview = f"(length: {len(proposed_fix_script)}) {proposed_fix_script[:100]}..." if proposed_fix_script else "None"
-            print(f"DiffusionCore.re_denoise_spans called. Context keys: {list(context_data.keys())}.")
+            failed_script_preview = (
+                f"(length: {len(failed_patch_script)}) {failed_patch_script[:100]}..."
+                if failed_patch_script
+                else "None"
+            )
+            proposed_script_preview = (
+                f"(length: {len(proposed_fix_script)}) {proposed_fix_script[:100]}..."
+                if proposed_fix_script
+                else "None"
+            )
+            print(
+                f"DiffusionCore.re_denoise_spans called. Context keys: {list(context_data.keys())}."
+            )
             print(f"  Verbose: Failed patch script (preview): {failed_script_preview}")
-            print(f"  Verbose: Proposed fix script (preview): {proposed_script_preview}")
+            print(
+                f"  Verbose: Proposed fix script (preview): {proposed_script_preview}"
+            )
         else:
             print(f"DiffusionCore.re_denoise_spans called.")
 
-        if proposed_fix_script and proposed_fix_script.startswith("# Original script commented out due to DUPLICATE_DETECTED"):
+        if proposed_fix_script and proposed_fix_script.startswith(
+            "# Original script commented out due to DUPLICATE_DETECTED"
+        ):
             if self.verbose:
-                print("DiffusionCore: Detected full script replacement proposal (e.g., for duplicate handling). Passing through.")
+                print(
+                    "DiffusionCore: Detected full script replacement proposal (e.g., for duplicate handling). Passing through."
+                )
             return proposed_fix_script
 
-        # TODO: Implement true span-based re-denoising.
-        # The current implementation passes through the proposed_fix_script for non-duplicate cases.
-        # Intended future logic:
-        # 1. Diff `failed_patch_script` and `proposed_fix_script` to identify specific changed regions/hunks.
-        #    (e.g., using difflib or a similar library to get sequence of changes).
-        #    if self.verbose: print("DiffusionCore: (Future) Diffing failed script and proposed fix to find changed spans.")
+        # Basic span-based merging of proposed fix into the failed script.
+        # Use difflib to rewrite only the changed regions while preserving
+        # unchanged lines from the failed script.
+        if proposed_fix_script is not None and failed_patch_script is not None:
+            try:
+                import difflib
 
-        # 2. Initialize `refined_script = failed_patch_script` (or a copy).
-        #    Iterate through identified spans that differ:
-        #    For each differing span:
-        #        - Identify the span in `failed_patch_script` (original_span_content, start_offset, end_offset).
-        #        - Identify the corresponding span in `proposed_fix_script` (llm_suggested_span_content).
-        #        - Extract prefix: `refined_script[:start_offset]`
-        #        - Extract suffix: `refined_script[end_offset:]` (adjust offsets if script is modified in place)
-        #        - Construct FIM prompt for a model like DivoT5:
-        #          fim_prompt = f"<PREFIX>{prefix}<SUFFIX>{suffix}<MIDDLE>"
-        #          # Or include llm_suggested_span_content as a hint in a more general prompt.
-        #          if self.verbose: print(f"DiffusionCore: (Future) Preparing FIM prompt for span. Prefix len: {len(prefix)}, Suffix len: {len(suffix)}")
+                failed_lines = failed_patch_script.splitlines()
+                proposed_lines = proposed_fix_script.splitlines()
+                matcher = difflib.SequenceMatcher(None, failed_lines, proposed_lines)
+                merged_lines = []
+                for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+                    if tag == "equal":
+                        merged_lines.extend(failed_lines[i1:i2])
+                    elif tag == "replace":
+                        merged_lines.extend(proposed_lines[j1:j2])
+                    elif tag == "delete":
+                        # skip lines from failed script
+                        continue
+                    elif tag == "insert":
+                        merged_lines.extend(proposed_lines[j1:j2])
 
-        #        - Conceptually call the infill model:
-        #          # infill_model_output = get_divot5_code_infill(model_dir_path=self.infill_model_path_for_divot5, prompt=fim_prompt, ...)
-        #          # if self.verbose: print(f"DiffusionCore: (Future) Received FIM output for span: {infill_model_output[:100]}...")
-
-        #        - Replace original_span_content in `refined_script` with `infill_model_output`.
-        #          # This requires careful management of offsets if script length changes.
-        #          # refined_script = prefix + infill_model_output + suffix (if processing one span at a time and rebuilding)
-        #          # Or, apply changes iteratively to a mutable representation of the script.
-
-        # If all spans processed successfully:
-        # if self.verbose: print("DiffusionCore: (Future) All spans processed by FIM model.")
-        # return refined_script
+                merged_script = "\n".join(merged_lines)
+                if self.verbose:
+                    print(
+                        "DiffusionCore: Span-based merge applied. Result length:",
+                        len(merged_script),
+                    )
+                return merged_script
+            except Exception as e_merge:
+                print(
+                    f"DiffusionCore Error: Span-based merge failed: {e_merge}. Falling back to proposed script."
+                )
+                # Fall through to returning proposed_fix_script below
 
         if proposed_fix_script is None:
-            print("DiffusionCore: No proposed fix script received from LLMCore (for targeted repair). Passing through None.")
+            print(
+                "DiffusionCore: No proposed fix script received from LLMCore (for targeted repair). Passing through None."
+            )
             return None
         else:
             if not isinstance(proposed_fix_script, str):
-                print(f"DiffusionCore Warning: proposed_fix_script is not a string (type: {type(proposed_fix_script)}). Attempting to cast.")
+                print(
+                    f"DiffusionCore Warning: proposed_fix_script is not a string (type: {type(proposed_fix_script)}). Attempting to cast."
+                )
                 try:
                     proposed_fix_script = str(proposed_fix_script)
                 except Exception as e_cast:
-                    print(f"DiffusionCore Error: Failed to cast proposed_fix_script to string: {e_cast}. Returning None.")
+                    print(
+                        f"DiffusionCore Error: Failed to cast proposed_fix_script to string: {e_cast}. Returning None."
+                    )
                     return None
 
-            print(f"DiffusionCore: (Fallback) Passing through LLM-proposed targeted fix script (length: {len(proposed_fix_script)}) as is. True span-based re-denoising is pending implementation.")
+            print(
+                f"DiffusionCore: (Fallback) Passing through LLM-proposed targeted fix script (length: {len(proposed_fix_script)}) as is. True span-based re-denoising is pending implementation."
+            )
             return proposed_fix_script

--- a/src/learning/ft_dataset.py
+++ b/src/learning/ft_dataset.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+from typing import List, Dict, Any
+
+from src.utils.memory_logger import load_success_memory
+
+
+def build_finetune_dataset(
+    data_dir: Path, output_path: Path, verbose: bool = False
+) -> bool:
+    """Create prompt-completion pairs from success_memory.jsonl."""
+    entries = load_success_memory(data_dir, verbose=verbose)
+    if not entries:
+        if verbose:
+            print(f"build_finetune_dataset: no entries found in {data_dir}")
+        return False
+
+    dataset: List[Dict[str, Any]] = []
+    for entry in entries:
+        issue = entry.get("spec_issue_description", "")
+        operations = entry.get("spec_operations_details", [])
+        diff = entry.get("successful_diff_summary", "")
+        source = entry.get("patch_source", "")
+        completion = entry.get("successful_script", "")
+        prompt = (
+            f"Issue: {issue}\n"
+            f"Operations: {operations}\n"
+            f"Patch Source: {source}\n"
+            f"Diff Summary:\n{diff}\n"
+            "\n# Response:\n"
+        )
+        dataset.append({"prompt": prompt, "completion": completion})
+
+    try:
+        with open(output_path, "w", encoding="utf-8") as f_out:
+            for item in dataset:
+                f_out.write(json.dumps(item) + "\n")
+        if verbose:
+            print(
+                f"build_finetune_dataset: wrote {len(dataset)} items to {output_path}"
+            )
+        return True
+    except Exception as e:
+        if verbose:
+            print(f"build_finetune_dataset: failed to write dataset: {e}")
+        return False

--- a/src/spec_normalizer/diffusion_spec_normalizer.py
+++ b/src/spec_normalizer/diffusion_spec_normalizer.py
@@ -3,71 +3,129 @@ from typing import Dict, Any, Optional
 from pathlib import Path
 
 from .spec_normalizer_interface import SpecNormalizerModelInterface
-from .t5_client import T5Client # For fallback
-from src.utils.config_loader import DEFAULT_APP_CONFIG # For default T5 path if needed by internal T5Client
+from .t5_client import T5Client  # Fallback implementation
+from src.utils.config_loader import DEFAULT_APP_CONFIG
+
+try:
+    import torch
+    from transformers import T5ForConditionalGeneration, T5TokenizerFast
+except ImportError:  # pragma: no cover - transformers is optional at runtime
+    torch = None  # type: ignore
+    T5ForConditionalGeneration = None  # type: ignore
+    T5TokenizerFast = None  # type: ignore
+    print(
+        "Warning: PyTorch or Hugging Face Transformers not available. DiffusionSpecNormalizer will use the T5 fallback only."
+    )
+
 
 class DiffusionSpecNormalizer(SpecNormalizerModelInterface):
     def __init__(self, app_config: Dict[str, Any]):
         self.app_config = app_config
         self.verbose = self.app_config.get("general", {}).get("verbose", False)
 
-        self.diffusion_model_path = self.app_config.get("models", {}).get("spec_diffusion_model_path") # New config key
+        self.diffusion_model_path = self.app_config.get("models", {}).get(
+            "spec_diffusion_model_path"
+        )
         self._is_diffusion_model_configured = False
         self.fallback_t5_client: Optional[T5Client] = None
+        self.model: Optional[T5ForConditionalGeneration] = None
+        self.tokenizer: Optional[T5TokenizerFast] = None
+        self.device: Optional[str] = None
+        self._is_ready: bool = False
 
-        if self.diffusion_model_path:
-            # Placeholder: In a real scenario, load/check the diffusion model
-            # For now, just checking if path is provided is enough to simulate "configured"
-            if Path(self.diffusion_model_path).exists(): # Basic check
-                self._is_diffusion_model_configured = True
-                if self.verbose:
-                    print(f"DiffusionSpecNormalizer: Configured with diffusion model path: {self.diffusion_model_path}")
+        if (
+            self.diffusion_model_path
+            and T5ForConditionalGeneration
+            and T5TokenizerFast
+            and torch
+        ):
+            model_path = Path(self.diffusion_model_path)
+            if model_path.exists():
+                try:
+                    self.device = "cuda" if torch.cuda.is_available() else "cpu"
+                    if self.verbose:
+                        print(
+                            f"DiffusionSpecNormalizer: Loading diffusion model from {model_path} on {self.device}"
+                        )
+                    self.tokenizer = T5TokenizerFast.from_pretrained(str(model_path))
+                    self.model = T5ForConditionalGeneration.from_pretrained(
+                        str(model_path)
+                    ).to(self.device)  # type: ignore
+                    self.model.eval()  # type: ignore
+                    self._is_diffusion_model_configured = True
+                    self._is_ready = True
+                except Exception as e:
+                    print(
+                        f"DiffusionSpecNormalizer Error: Failed to load diffusion model from {model_path}: {e}"
+                    )
+                    self._is_diffusion_model_configured = False
             else:
                 if self.verbose:
-                    print(f"DiffusionSpecNormalizer Warning: Diffusion model path {self.diffusion_model_path} provided but not found. Will use T5 fallback.")
+                    print(
+                        f"DiffusionSpecNormalizer Warning: Diffusion model path {model_path} not found. Falling back to T5Client."
+                    )
 
         if not self._is_diffusion_model_configured:
             if self.verbose:
-                print("DiffusionSpecNormalizer: Diffusion model not configured or path invalid. Initializing T5Client as fallback.")
-            # Pass the main app_config to T5Client so it can find its own model paths
+                print(
+                    "DiffusionSpecNormalizer: Diffusion model unavailable. Initializing T5Client as fallback."
+                )
             self.fallback_t5_client = T5Client(app_config=self.app_config)
 
     @property
     def is_ready(self) -> bool:
-        if self._is_diffusion_model_configured:
-            # Placeholder: Real check for diffusion model readiness
+        if self._is_diffusion_model_configured and self._is_ready:
             return True
         if self.fallback_t5_client:
             return self.fallback_t5_client.is_ready
         return False
 
-    def generate_spec_yaml(self, raw_issue_text: str, context_symbols_string: Optional[str] = None) -> Optional[str]:
-        if self._is_diffusion_model_configured:
+    def generate_spec_yaml(
+        self, raw_issue_text: str, context_symbols_string: Optional[str] = None
+    ) -> Optional[str]:
+        if self._is_diffusion_model_configured and self.model and self.tokenizer:
             if self.verbose:
-                print(f"DiffusionSpecNormalizer: Would use diffusion model for: {raw_issue_text[:50]}...")
-            # Placeholder: Actual call to diffusion model
-            context_info_for_mock = "No context symbols provided."
-            if context_symbols_string:
-                context_info_for_mock = context_symbols_string[:200] + "..." if len(context_symbols_string) > 200 else context_symbols_string
+                print(
+                    f"DiffusionSpecNormalizer: Generating spec with diffusion model for: {raw_issue_text[:50]}..."
+                )
 
-            mock_yaml = f'''
-issue_description: "Processed by (placeholder) DiffusionSpecNormalizer: {raw_issue_text[:100]}"
-target_files:
-  - "src/mock/diffusion_target.py"
-operations:
-  - name: "diffusion_generated_op"
-    description: "Operation suggested by diffusion spec normalizer."
-context_used: |
-  {context_info_for_mock}
-acceptance_tests:
-  - "Ensure diffusion normalization worked."
-'''
-            return mock_yaml.strip()
-        elif self.fallback_t5_client and self.fallback_t5_client.is_ready:
+            prompt = (
+                "Translate the following issue description and context into a YAML specification.\n\n"
+                f"Context symbols:\n{context_symbols_string if context_symbols_string else 'None'}\n\n"
+                f"Issue:\n{raw_issue_text}\n\nGenerate YAML:"
+            )
+            try:
+                inputs = self.tokenizer(
+                    prompt,
+                    return_tensors="pt",
+                    max_length=1024,
+                    truncation=True,
+                    padding="longest",
+                ).to(self.device)
+                gen_cfg = {"max_length": 512, "num_beams": 4, "early_stopping": True}
+                outputs = self.model.generate(inputs.input_ids, **gen_cfg)  # type: ignore
+                yaml_str = self.tokenizer.decode(
+                    outputs[0], skip_special_tokens=True
+                ).strip()
+                if self.verbose:
+                    print(f"DiffusionSpecNormalizer: Model output:\n{yaml_str}")
+                return yaml_str
+            except Exception as e:
+                print(
+                    f"DiffusionSpecNormalizer Error: Inference failed: {e}. Falling back to T5Client."
+                )
+
+        if self.fallback_t5_client and self.fallback_t5_client.is_ready:
             if self.verbose:
-                print(f"DiffusionSpecNormalizer: Using T5Client fallback for: {raw_issue_text[:50]}...")
-            return self.fallback_t5_client.generate_spec_yaml(raw_issue_text, context_symbols_string)
+                print(
+                    f"DiffusionSpecNormalizer: Using T5Client fallback for: {raw_issue_text[:50]}..."
+                )
+            return self.fallback_t5_client.generate_spec_yaml(
+                raw_issue_text, context_symbols_string
+            )
         else:
             if self.verbose:
-                print("DiffusionSpecNormalizer Error: Neither diffusion model nor T5 fallback is ready.")
+                print(
+                    "DiffusionSpecNormalizer Error: Neither diffusion model nor T5 fallback is ready."
+                )
             return None


### PR DESCRIPTION
## Summary
- add T5-based diffusion spec normalizer with fallback logic
- merge failing patches by span rather than replacing whole script
- log patch diff embeddings to success memory and add dataset builder
- add CLI helpers for training and running the assistant

## Testing
- `black src/agent_group/diffusion_core.py src/utils/memory_logger.py src/learning/ft_dataset.py`
- `ruff format src/agent_group/diffusion_core.py src/utils/memory_logger.py src/learning/ft_dataset.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'libcst')*

------
https://chatgpt.com/codex/tasks/task_e_684de5a0f2d483309da8673f6847f649